### PR TITLE
Replace nonexistent uid command with id.

### DIFF
--- a/setup
+++ b/setup
@@ -261,7 +261,7 @@ Invoke the utility by typing '/opt/ooce/bin/omni'
 or add /opt/ooce/bin to your \$PATH
 
 EOM
-elif [ "`uid -u`" = 0 ] && ask "Create symlink as /usr/bin/omni?"; then
+elif [ "`id -u`" = 0 ] && ask "Create symlink as /usr/bin/omni?"; then
 	[ -h /usr/bin/omni ] && rm -f /usr/bin/omni
 	ln -s `pwd`/bin/omni /usr/bin/omni
 	echo


### PR DESCRIPTION
I hit this bug today when building illumos. I see that a change went in yesterday and a `uid` command was used to extract the the UID. Since I don't have `uid` (perhaps it's provided by an external package?) the `id` command should suffice.