### PR TITLE
Use existing branch names

### DIFF
--- a/setup
+++ b/setup
@@ -33,7 +33,7 @@ fi
 
 if (( relnum % 2 == 0 )); then
 	release="r$relnum"
-	branch=$relnum
+	branch="r$relnum"
 else
 	release=bloody
 	branch=master


### PR DESCRIPTION
Branches on repositories are named with an initial r.

Prior to https://github.com/omniosorg/omni/pull/17 the value of $branch got set to a contain an r through `uname -v | cut -d- -f2`, resulting in correct names. The commit in PR-17 changes $branch to instead be all numerical, which presumably must have been a mistake since that is not how they actually are named.