### PR TITLE
template-gcc10: use gcc14 as shadow compiler

### DIFF
--- a/etc/template-gcc10.env
+++ b/etc/template-gcc10.env
@@ -38,7 +38,7 @@ SMATCHBIN+=/opt/onbld/bin/$MACH/smatch
 GNUC_ROOT="/opt/gcc-10/"
 PRIMARY_CC="gcc10,/opt/gcc-10/bin/gcc,gnu"
 PRIMARY_CCC="gcc10,/opt/gcc-10/bin/g++,gnu"
-SHADOW_CCS="gcc7,/opt/gcc-7/bin/gcc,gnu smatch,$SMATCHBIN,smatch"
-SHADOW_CCCS="gcc7,/opt/gcc-7/bin/g++,gnu"
+SHADOW_CCS="gcc14,/opt/gcc-14/bin/gcc,gnu smatch,$SMATCHBIN,smatch"
+SHADOW_CCCS="gcc14,/opt/gcc-14/bin/g++,gnu"
 export GNUC_ROOT PRIMARY_CC PRIMARY_CCC SHADOW_CCS SHADOW_CCCS
 


### PR DESCRIPTION
This template is used for r151054 builds that don't have gcc7. This causes build to crash. Let's use
gcc14 as shadow compiler as it's done in commit b7fe974ee38 in repository omniosorg/illumos-omnios.