### PR TITLE
setup: don't block on ask() when stdin is not a terminal

### DIFF
--- a/setup
+++ b/setup
@@ -43,6 +43,8 @@ ask()
 {
 	typeset a=
 
+	[ -t 0 ] || return 1
+
 	echo "$* (y/n) \\c"
 	while [[ "$a" != [yYnN] ]]; do
 		read -r a


### PR DESCRIPTION
When setup is invoked non-interactively (CI, scripts, pipes), read(1) inside ask() blocks indefinitely waiting for input that never arrives.

Check whether stdin is a terminal before attempting to read; if not, return 1 (answer "no") and let the caller decide whether that matters. This is consistent with the ask() implementation in bin/omni, which already supports non-interactive use.