### PR TITLE
bin: omni: exit 1 when omni has not been configured

### DIFF
--- a/bin/omni
+++ b/bin/omni
@@ -52,7 +52,7 @@ Where <build directory> points to an empty directory that will be used
 for building OmniOS.
 
 	EOM
-	exit 0
+	exit 1
 fi
 
 # shellcheck disable=SC1090


### PR DESCRIPTION
Previously, omni exited with code 0 (success) when ~/.omni did not exist. This is incorrect: the tool was invoked but could not perform any work, which is an error condition, not a successful no-op.

A zero exit code misleads callers that check $? or use set -e, and causes subprocess wrappers with check=True (e.g. in CI scripts) to silently continue past a configuration failure instead of aborting.